### PR TITLE
refactor(CEECORE-2932): replace deprecated render methods and unnecessary dependencies in frameworkLib

### DIFF
--- a/packages/subapp-react/README.md
+++ b/packages/subapp-react/README.md
@@ -73,12 +73,6 @@ import { React, loadSubApp } from "subapp-react";
 export default loadSubApp({ name: "MySubapp", Component, useReactRouter: true });
 ```
 
-## Support for SSR with Suspense
-
-async server side rendering with React suspense is enabled with [react-async-ssr]
-
-- First, you have to install [react-async-ssr] with `npm i react-async-ssr`
-
 ## License
 
 Copyright (c) 2016-present, WalmartLabs

--- a/packages/subapp-react/README.md
+++ b/packages/subapp-react/README.md
@@ -82,4 +82,3 @@ Licensed under the [Apache License, Version 2.0].
 [apache license, version 2.0]: https://www.apache.org/licenses/LICENSE-2.0
 [react-router]: https://www.npmjs.com/package/react-router
 [react-router-dom]: https://www.npmjs.com/package/react-router-dom
-[react-async-ssr]: https://www.npmjs.com/package/react-async-ssr

--- a/packages/subapp-react/lib/framework-lib.js
+++ b/packages/subapp-react/lib/framework-lib.js
@@ -68,14 +68,14 @@ class FrameworkLib {
     if (options.useStream) {
       assert(!options.suspenseSsr, "useStream and suspense SSR together are not supported");
       if (options.hydrateServerData) {
-           // TODO: Deprecated in React 18 https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-server-rendering-apis
-           // FIXME: use renderToPipeableStream
-           // React 18 info: It will work in 18, including the new Suspense features described below, but it will buffer the entire content until the end of the stream. In other words, it will no longer do streaming.
-           return ReactDOMServer.renderToNodeStream(element);
+        // TODO: Deprecated in React 18 https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-server-rendering-apis
+        // FIXME: use renderToPipeableStream
+        // React 18 info: It will work in 18, including the new Suspense features described below, but it will buffer the entire content until the end of the stream. In other words, it will no longer do streaming.
+        return ReactDOMServer.renderToNodeStream(element);
       } else {
         // TODO: Deprecated (with full Suspense support, but without streaming) in React 18.
         // FIXME: 18 Unhandled Breaking Change: It adds trailing comment nodes to any text node. https://github.com/facebook/react/pull/23359
-        return ReactDOMServer.renderToStaticNodeStream(element);
+        return ReactDOMServer.renderToPipeableStream(element);
       }
     }
     if (options.suspenseSsr) {

--- a/packages/subapp-react/lib/framework-lib.js
+++ b/packages/subapp-react/lib/framework-lib.js
@@ -6,7 +6,6 @@ const assert = require("assert");
 const optionalRequire = require("optional-require")(require);
 const React = require("react");
 const ReactDOMServer = require("react-dom/server");
-const AsyncReactDOMServer = optionalRequire("react-async-ssr");
 const { default: AppContext } = require("../dist/node/app-context");
 const ReactRedux = optionalRequire("react-redux", { default: {} });
 const { Provider } = ReactRedux;
@@ -65,29 +64,8 @@ class FrameworkLib {
       return subAppServer.renderer(element, options);
     }
 
-    if (options.useStream) {
-      assert(!options.suspenseSsr, "useStream and suspense SSR together are not supported");
-      if (options.hydrateServerData) {
-        // TODO: Deprecated in React 18 https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-server-rendering-apis
-        // FIXME: use renderToPipeableStream
-        // React 18 info: It will work in 18, including the new Suspense features described below, but it will buffer the entire content until the end of the stream. In other words, it will no longer do streaming.
-        return ReactDOMServer.renderToNodeStream(element);
-      } else {
-        // TODO: Deprecated (with full Suspense support, but without streaming) in React 18.
-        // FIXME: 18 Unhandled Breaking Change: It adds trailing comment nodes to any text node. https://github.com/facebook/react/pull/23359
-        return ReactDOMServer.renderToPipeableStream(element);
-      }
-    }
-    if (options.suspenseSsr) {
-      assert(AsyncReactDOMServer, "You must install react-async-ssr for suspense SSR support");
-      if (options.hydrateServerData) {
-        return AsyncReactDOMServer.renderToStringAsync(element);
-      } else {
-        return AsyncReactDOMServer.renderToStaticMarkupAsync(element);
-      }
-    }
-    if (options.hydrateServerData) {
-      return ReactDOMServer.renderToString(element);
+    if (options.suspenseSsr || options.useStream || options.hydrateServerData) {
+      return ReactDOMServer.renderToPipeableStream(element);
     } else {
       return ReactDOMServer.renderToStaticMarkup(element);
     }

--- a/packages/subapp-react/package.json
+++ b/packages/subapp-react/package.json
@@ -49,7 +49,6 @@
     "electrode-archetype-njs-module-dev": "^3.0.3",
     "jsdom": "^15.2.1",
     "react": "^18.0.0",
-    "react-async-ssr": "^0.6.0",
     "react-dom": "^18.0.0",
     "react-redux": "^6.0.1",
     "react-router": "^5.1.2",

--- a/packages/subapp-react/test/spec/ssr-framework.spec.js
+++ b/packages/subapp-react/test/spec/ssr-framework.spec.js
@@ -323,7 +323,7 @@ describe("SSR React framework", function () {
     expect(framework.initialStateStr).equals(`{}`);
   });
 
-  it("should hydrate render Component with suspense using react-async-ssr", async () => {
+  it("should hydrate render Component with suspense", async () => {
     const framework = new lib.FrameworkLib({
       subApp: {
         Component: props => {
@@ -349,7 +349,7 @@ describe("SSR React framework", function () {
     expect(output.result).contains("Hello <!-- -->foo bar");
   });
 
-  it("should render Component with suspense using react-async-ssr", async () => {
+  it("should render Component with suspense", async () => {
     const framework = new lib.FrameworkLib({
       subApp: {
         Component: props => {

--- a/packages/subapp-react/test/spec/ssr-framework.spec.js
+++ b/packages/subapp-react/test/spec/ssr-framework.spec.js
@@ -9,7 +9,7 @@ const { connect } = require("react-redux");
 const { Stream } = require("stream");
 
 describe("SSR React framework", function () {
-  function getTestWritable() {
+  const getTestWritable = () => {
     const writable = new Stream.PassThrough();
     writable.setEncoding("utf8");
     const output = { result: "", error: undefined };
@@ -28,8 +28,7 @@ describe("SSR React framework", function () {
       });
     });
     return { writable, completed, output };
-  }
-  const { writable, output, completed } = getTestWritable();
+  };
 
   it("should setup React framework", () => {
     expect(lib.React).to.be.ok;
@@ -114,6 +113,7 @@ describe("SSR React framework", function () {
   });
 
   it("should render Component with stream if enabled", async () => {
+    const { writable, output, completed } = getTestWritable();
     const framework = new lib.FrameworkLib({
       subApp: {
         prepare: () => ({ test: "foo bar" }),
@@ -135,6 +135,7 @@ describe("SSR React framework", function () {
   });
 
   it("should hydrate render Component with stream if enabled", async () => {
+    const { writable, output, completed } = getTestWritable();
     const framework = new lib.FrameworkLib({
       subApp: {
         prepare: () => ({ test: "foo bar" }),
@@ -156,6 +157,7 @@ describe("SSR React framework", function () {
   });
 
   it("should render Component from subapp with hydration info", async () => {
+    const { writable, output, completed } = getTestWritable();
     const framework = new lib.FrameworkLib({
       subApp: {
         prepare: () => ({
@@ -324,6 +326,7 @@ describe("SSR React framework", function () {
   });
 
   it("should hydrate render Component with suspense", async () => {
+    const { writable, output, completed } = getTestWritable();
     const framework = new lib.FrameworkLib({
       subApp: {
         Component: props => {
@@ -350,6 +353,7 @@ describe("SSR React framework", function () {
   });
 
   it("should render Component with suspense", async () => {
+    const { writable, output, completed } = getTestWritable();
     const framework = new lib.FrameworkLib({
       subApp: {
         Component: props => {

--- a/samples/poc-subapp-redux/package.json
+++ b/samples/poc-subapp-redux/package.json
@@ -43,7 +43,6 @@
     "history": "^4.10.1",
     "html-webpack-plugin": "^5.3.1",
     "react": "^18.0.0",
-    "react-async-ssr": "^0.7.2",
     "react-dom": "^18.0.0",
     "react-redux": "^7.2.0",
     "react-router": "^5.2.0",

--- a/samples/poc-subapp/package.json
+++ b/samples/poc-subapp/package.json
@@ -43,7 +43,6 @@
     "history": "^4.10.1",
     "html-webpack-plugin": "^5.3.1",
     "react": "^18.0.0",
-    "react-async-ssr": "^0.7.2",
     "react-dom": "^18.0.0",
     "react-redux": "^7.2.0",
     "react-router": "^5.2.0",


### PR DESCRIPTION
- Replace deprecated render methods with new `renderToPipeableStream` method in **framework-lib.js**
- Remove `react-async-ssr` dependency from  **framework-lib.js**
- Update **ssr-framework.spec.js** to work with `renderToPipeableNodeStream` method.
- Remove `react-async-ssr` references from **ssr-framework.spec.js**
- Remove `react-async-ssr` references **README.MD**
- Remove `react-async-ssr` from **package.json** files


