### PR TITLE
refactor(CEECORE-3041): Remove method renderToStaticMarkup from frame…

### DIFF
--- a/packages/subapp-react/README.md
+++ b/packages/subapp-react/README.md
@@ -73,12 +73,6 @@ import { React, loadSubApp } from "subapp-react";
 export default loadSubApp({ name: "MySubapp", Component, useReactRouter: true });
 ```
 
-## Support for SSR with Suspense
-
-async server side rendering with React suspense is enabled with [react-async-ssr]
-
-- First, you have to install [react-async-ssr] with `npm i react-async-ssr`
-
 ## License
 
 Copyright (c) 2016-present, WalmartLabs
@@ -88,4 +82,3 @@ Licensed under the [Apache License, Version 2.0].
 [apache license, version 2.0]: https://www.apache.org/licenses/LICENSE-2.0
 [react-router]: https://www.npmjs.com/package/react-router
 [react-router-dom]: https://www.npmjs.com/package/react-router-dom
-[react-async-ssr]: https://www.npmjs.com/package/react-async-ssr

--- a/packages/subapp-react/package.json
+++ b/packages/subapp-react/package.json
@@ -49,7 +49,6 @@
     "electrode-archetype-njs-module-dev": "^3.0.3",
     "jsdom": "^15.2.1",
     "react": "^18.0.0",
-    "react-async-ssr": "^0.6.0",
     "react-dom": "^18.0.0",
     "react-redux": "^6.0.1",
     "react-router": "^5.1.2",

--- a/samples/poc-subapp-redux/package.json
+++ b/samples/poc-subapp-redux/package.json
@@ -43,7 +43,6 @@
     "history": "^4.10.1",
     "html-webpack-plugin": "^5.3.1",
     "react": "^18.0.0",
-    "react-async-ssr": "^0.7.2",
     "react-dom": "^18.0.0",
     "react-redux": "^7.2.0",
     "react-router": "^5.2.0",

--- a/samples/poc-subapp/package.json
+++ b/samples/poc-subapp/package.json
@@ -43,7 +43,6 @@
     "history": "^4.10.1",
     "html-webpack-plugin": "^5.3.1",
     "react": "^18.0.0",
-    "react-async-ssr": "^0.7.2",
     "react-dom": "^18.0.0",
     "react-redux": "^7.2.0",
     "react-router": "^5.2.0",


### PR DESCRIPTION
…workLib and update test (#1883)

* test: resolve CEECORE-2971

* feat(CEECORE-2971): upgrade to React v18

* test(CEECORE-2971): remove comments from fe-frameworkLib CSR test

* test(CEECORE-2980): refactor test to work with renderToPipeableNodeStream

* refactor(CEECORE-2932): replace depricated render methods and unnecessary dependecies in frameworkLib

* test(CEECORE-2932): update ssr-framework test to work with renderToPipeableNodeStream

* test(CEECORE-2932): remove react-async-ssr references from ssr-framework test

* docs: remove react-async-ssr reference from README

* docs: remove react-async-ssr reference from README

* refactor: remove react-async-ssr from package.json files

* refactor: remove react-async-ssr from package.json files

* fix: run getTestWritable() within tests and define as an arrow function

* remove renderToStaticMarkup and refactor test in subapp-react

Co-authored-by: Mateja Ristic <matejaristic@MatejaR-USMAC22.local>
Co-authored-by: Mateja Ristic <matejaristic@MatejaR-USMAC22.lan>